### PR TITLE
Fixed database migrations.

### DIFF
--- a/knexfile.ts
+++ b/knexfile.ts
@@ -4,6 +4,8 @@
 
 require('ts-node/register');
 
+import knex from 'knex';
+
 // Config
 import configMan from './server/managers/config';
 
@@ -17,14 +19,24 @@ import { getConfig } from './server/managers/database';
 
 //----------------------------------------------------------------------------------------------------------------------
 
-module.exports = {
-    ...getConfig(),
-    migrations: {
-        directory: './server/knex/migrations'
-    },
-    seeds: {
-        directory: './server/knex/seeds'
-    }
+module.exports = async () =>
+{
+    const db = knex(getConfig());
+
+    // When this file is run, it expects the migrations to end in .ts, so accommodate that.
+    await db.update({ name: db.raw('replace(name, \'.js\', \'.ts\')') })
+        .from('knex_migrations');
+
+    return {
+        ...getConfig(),
+        migrations: {
+            directory: './server/knex/migrations',
+            extension: 'ts'
+        },
+        seeds: {
+            directory: './server/knex/seeds'
+        }
+    };
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "main": "server.js",
   "scripts": {
     "start": "npm run build:server && DEBUG=true node ./dist/server.js",
-    "db:migrate": "knex migrate:latest && knex seed:run",
-    "db:seeds": "knex seed:run",
     "build:server": "tsc",
     "build:distclean": "rimraf dist/* .cache",
     "build:clean": "rimraf dist/*",
@@ -32,7 +30,6 @@
     "decoders": "^1.23.3",
     "express": "^4.17.1",
     "express-session": "^1.17.1",
-    "gravatar": "^1.3.1",
     "helmet": "^4.4.1",
     "knex": "^0.21.1",
     "lodash": "^4.17.19",


### PR DESCRIPTION
Now we can move back to auto-migration, but fix the migration file endings.

Also, this fixes deployments needing migrations to be run, but not including all the files to run them.