### PR TITLE
Fix repository typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint \"src/**/*.{ts,js,vue}\" --max-warnings=0 --no-warn-ignored",
     "prepare": "if-env NODE_ENV=production && exit 0 || husky"
   },
-  "repository": "Morgul/rpgkkeper",
+  "repository": "Morgul/rpgkeeper",
   "author": "Christopher S. Case <chris.case@g33xnexus.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary
- correct Morgul/rpgkkeper typo in `package.json` repository field

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8b5575f0832f9529b05f6330b8cd