### PR TITLE
Implement account update authorization

### DIFF
--- a/src/server/routes/accounts.ts
+++ b/src/server/routes/accounts.ts
@@ -80,8 +80,22 @@ router.patch(
     }),
     async (req, resp) =>
     {
+        const user = req.user;
+        const targetID = req.params.accountID;
+
+        // Ensure the user is modifying their own account, or has the right perm
+        if(user.id !== targetID && !permsMan.hasPerm(user, 'Accounts/canModify'))
+        {
+            resp.status(403)
+                .json({
+                    type: 'NotAuthorized',
+                    message: `You are not authorized to update account '${ targetID }'.`,
+                });
+            return;
+        }
+
         // Update the account
-        const newAccount = await accountMan.update(req.params.accountID, req.body);
+        const newAccount = await accountMan.update(targetID, req.body);
         resp.json(newAccount);
     }
 );


### PR DESCRIPTION
## Summary
- enforce permission check when updating accounts
- remove temporary unit tests and test script

## Testing
- `npm run lint`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_683f966579a8832fb651800cc66bf725